### PR TITLE
fix(npm): combine both npm installs to a single npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "client-install": "npm install --prefix client",
+    "postinstall": "cd client && npm install",
     "start": "node server.js",
     "server": "nodemon server.js",
     "client": "npm start --prefix client",


### PR DESCRIPTION
add `postinstall` to package.json so that the packages required for the 
client will be installed along with the base `npm install`.